### PR TITLE
Add tag release action

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -25,9 +25,18 @@ jobs:
       - name: Calculate next version
         id: version
         run: |
-          # Try to extract version from PR title first
-          pr_title=""
-          if [ "${{ github.event_name }}" == "push" ]; then
+          new_version=""
+          
+          # If manual dispatch with set_version, use that (highest priority)
+          if [ -n "${{ github.event.inputs.set_version }}" ]; then
+            new_version="${{ github.event.inputs.set_version }}"
+            # Add 'v' prefix if not present
+            if [[ ! $new_version =~ ^v ]]; then
+              new_version="v$new_version"
+            fi
+            echo "Using manual version: $new_version"
+          # If push event, try to extract version from PR title
+          elif [ "${{ github.event_name }}" == "push" ]; then
             # Get the PR title from the merge commit message
             commit_message=$(git log -1 --format='%s')
             echo "Commit message: $commit_message"
@@ -38,39 +47,22 @@ jobs:
               new_version="v$extracted_version"
               echo "Extracted version from PR title: $new_version"
             else
-              echo "Could not extract version from commit message, falling back to auto-increment"
-              extracted_version=""
+              echo "❌ Could not extract version from commit message"
+              echo "Expected format: 'chore: 🐝 Update SDK - Generate X.X.X'"
+              echo "Actual message: $commit_message"
             fi
           fi
           
-          # If manual dispatch with set_version, use that
-          if [ -n "${{ github.event.inputs.set_version }}" ]; then
-            new_version="${{ github.event.inputs.set_version }}"
-            # Add 'v' prefix if not present
-            if [[ ! $new_version =~ ^v ]]; then
-              new_version="v$new_version"
-            fi
-            echo "Using manual version: $new_version"
-          # If we extracted version from PR title, use that
-          elif [ -n "$extracted_version" ]; then
-            new_version="v$extracted_version"
-            echo "Using extracted version: $new_version"
-          else
-            # Fall back to auto-increment
-            latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.2.6")
-            echo "Latest tag: $latest_tag"
-            
-            # Extract version numbers and increment patch
-            version=${latest_tag#v}
-            IFS='.' read -r major minor patch <<< "$version"
-            
-            # Increment patch version
-            new_patch=$((patch + 1))
-            new_version="v$major.$minor.$new_patch"
-            echo "Auto-incremented version: $new_version"
+          # Validate that we have a version
+          if [ -z "$new_version" ]; then
+            echo "❌ No version could be determined. Workflow will exit."
+            echo "Please either:"
+            echo "  1. Use workflow_dispatch with set_version input, or"
+            echo "  2. Ensure PR title contains 'Generate X.X.X' pattern"
+            exit 1
           fi
           
-          echo "Final version: $new_version"
+          echo "✅ Final version: $new_version"
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Configure Git


### PR DESCRIPTION
Adding automated tagging action which will trigger the publish action

The publish action relies on a tag to be applied to in order to run. This will automate application of the tag. 
It will pull the version from the pull request opened by the bot and tag the latest commit, triggering the release.

Successful publish after pushing tag:
https://github.com/firehydrant/terraform-provider-firehydrant-v2/actions/runs/16125433880