### PR TITLE
Add manual mappings, ignores related to on call schedules, shifts

### DIFF
--- a/scripts/overlay/manual-mappings.yaml
+++ b/scripts/overlay/manual-mappings.yaml
@@ -52,6 +52,18 @@ operations:
     method: "get"
     action: "ignore"
 
+  # Ignoring create, update, delete operations for on call schedule shifts
+  # These operations should not be supported in the provider, but read to enable the datasource is supported
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}/shifts"
+    method: "post"
+    action: "ignore"
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}/shifts/{shift_id}"
+    method: "patch"
+    action: "ignore"
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}/shifts/{shift_id}"
+    method: "delete"
+    action: "ignore"
+
   # Manual Entity Mappings
   # Signals Event Sources
   - path: "/v1/signals/event_sources/{transposer_slug}"
@@ -148,6 +160,37 @@ operations:
     action: "match"
     value: "team_id:handoff_step.target.id"
 
+    # Signals On Call Schedules
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}"
+    method: "get"
+    action: "match"
+    value: "schedule_id:id"
+
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}"
+    method: "patch"
+    action: "match"
+    value: "schedule_id:id"
+
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}"
+    method: "delete"
+    action: "match"
+    value: "schedule_id:id"
+
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}"
+    method: "get"
+    action: "match"
+    value: "team_id:team.id"
+
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}"
+    method: "patch"
+    action: "match"
+    value: "team_id:team.id"
+
+  - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}"
+    method: "delete"
+    action: "match"
+    value: "team_id:team.id"
+    
 # Task Lists
   - path: "/v1/task_lists"
     method: "get"

--- a/scripts/overlay/terraform-viable.go
+++ b/scripts/overlay/terraform-viable.go
@@ -155,10 +155,10 @@ func validateOperationParameters(resource *ResourceInfo, primaryID string, schem
 
 				// If the manual mapping points to a valid entity field (including nested), it's acceptable
 				if checkFieldExistsInEntityWithRefResolution(manualMatch, entityProps, schemas) {
-
+					fmt.Printf("    Manual mapping %s -> %s points to valid entity field (including nested)\n", param, manualMatch)
 					continue
 				} else {
-
+					fmt.Printf("    Manual mapping %s -> %s points to non-existent entity field\n", param, manualMatch)
 					hasConflictingEntityIDs = true
 					break
 				}
@@ -274,39 +274,30 @@ func isSystemProperty(propName string) bool {
 func checkFieldExistsInEntityWithRefResolution(fieldPath string, entityProps map[string]interface{}, schemas map[string]interface{}) bool {
 	parts := strings.Split(fieldPath, ".")
 
-	fmt.Printf("    Debug: Checking field path: %s (parts: %v)\n", fieldPath, parts)
-
 	currentLevel := entityProps
 
 	for i, part := range parts {
-		fmt.Printf("    Debug: Looking for part '%s' at level %d\n", part, i)
 
 		if prop, exists := currentLevel[part]; exists {
-			fmt.Printf("    Debug: Found part '%s'\n", part)
 
 			if i == len(parts)-1 {
-				fmt.Printf("    Debug: Reached final part, field exists: %s\n", fieldPath)
 				return true
 			}
 
 			if propMap, ok := prop.(map[string]interface{}); ok {
 				// Check if it has direct properties
 				if nestedProps, hasProps := propMap["properties"].(map[string]interface{}); hasProps {
-					fmt.Printf("    Debug: Found direct properties for '%s'\n", part)
 					currentLevel = nestedProps
 					continue
 				}
 
 				// Check if it has a $ref that needs resolution
 				if ref, hasRef := propMap["$ref"].(string); hasRef {
-					fmt.Printf("    Debug: Found $ref '%s' for part '%s'\n", ref, part)
 
 					resolvedSchema := resolveSchemaRef(ref, schemas)
 					if resolvedSchema != nil {
-						fmt.Printf("    Debug: Successfully resolved $ref '%s'\n", ref)
 
 						if refProps, hasRefProps := resolvedSchema["properties"].(map[string]interface{}); hasRefProps {
-							fmt.Printf("    Debug: Found properties in resolved schema\n")
 							currentLevel = refProps
 							continue
 						} else {


### PR DESCRIPTION
Adds manual mappings and improved manual mapping logic to restore on call schedule resource. We also add ignores for specific on call schedule shift operations to prevent creation of an independent shifts resource. 

Restored on call schedule resource (and no shifts resource):
<img width="422" height="686" alt="Screenshot 2025-07-15 at 3 00 12 PM" src="https://github.com/user-attachments/assets/dc55d7b4-2b3e-4c69-8cd0-fc5821ffcb80" />

Schedule and Shifts data sources:
<img width="402" height="355" alt="Screenshot 2025-07-15 at 3 00 48 PM" src="https://github.com/user-attachments/assets/3f5f11ba-7217-4585-a4ce-eba670b297fd" />
