### PR TITLE
RD-81: Enable Specific Entities

### DIFF
--- a/scripts/overlay/manual-mappings.yaml
+++ b/scripts/overlay/manual-mappings.yaml
@@ -5,6 +5,8 @@
 # - "ignore_property": Ignore a specific property on an entity, specify schema and property
 # - "additional_properties": Add additionalProperties: true to a specific property on an entity, specify schema and property
 #    this is a workaround for empty hashes in our Grape API
+# - "enable": Enable an entity for gradual provider rollout. With no enable action types, all entities are enabled by default.
+#    there is no explicit "disable", if there is a single enable action then ONLY entities which are enable will be processed
 
 operations:
   # IGNORE: Skip operations that shouldn't be treated as entity operations
@@ -62,6 +64,13 @@ operations:
     action: "ignore"
   - path: "/v1/teams/{team_id}/on_call_schedules/{schedule_id}/shifts/{shift_id}"
     method: "delete"
+    action: "ignore"
+
+
+  # The patch is causing generation issues
+  # Temporary workaround to avoid compilation errors
+  - path: "/v1/incidents/{incident_id}/retrospectives/{retrospective_id}/fields/{field_id}"
+    method: "patch"
     action: "ignore"
 
   # Manual Entity Mappings
@@ -467,3 +476,6 @@ operations:
     schema: "Integrations_Aws_CloudtrailBatchEntity"
     property: "connection"
 
+
+  - action: "enable"
+    entity: "FunctionalityEntity"

--- a/scripts/overlay/manual-mappings_test.go
+++ b/scripts/overlay/manual-mappings_test.go
@@ -29,6 +29,10 @@ func TestLoadManualMappings(t *testing.T) {
 		testMappings := ManualMappings{
 			Operations: []ManualMapping{
 				{
+					Action: "enable",
+					Entity: "UserEntity",
+				},
+				{
 					Path:   "/users/{id}",
 					Method: "get",
 					Action: "match",
@@ -79,54 +83,62 @@ func TestLoadManualMappings(t *testing.T) {
 		if mappings == nil {
 			t.Error("expected non-nil mappings")
 		}
-		if mappings == nil || len(mappings.Operations) != 5 {
-			t.Errorf("expected 5 operations, got %d", len(mappings.Operations))
+		if mappings == nil || len(mappings.Operations) != 6 {
+			t.Errorf("expected 6 operations, got %d", len(mappings.Operations))
+		}
+
+		// Verify enable operation
+		if mappings.Operations[0].Action != "enable" {
+			t.Errorf("expected action 'enable', got '%s'", mappings.Operations[0].Action)
+		}
+		if mappings.Operations[0].Entity != "UserEntity" {
+			t.Errorf("expected entity 'UserEntity', got '%s'", mappings.Operations[0].Entity)
 		}
 
 		// Verify first operation
-		if mappings.Operations[0].Path != "/users/{id}" {
-			t.Errorf("expected path '/users/{id}', got '%s'", mappings.Operations[0].Path)
+		if mappings.Operations[1].Path != "/users/{id}" {
+			t.Errorf("expected path '/users/{id}', got '%s'", mappings.Operations[1].Path)
 		}
-		if mappings.Operations[0].Action != "match" {
-			t.Errorf("expected action 'match', got '%s'", mappings.Operations[0].Action)
+		if mappings.Operations[1].Action != "match" {
+			t.Errorf("expected action 'match', got '%s'", mappings.Operations[1].Action)
 		}
-		if mappings.Operations[0].Value != "id:user_id" {
-			t.Errorf("expected value 'id:user_id', got '%s'", mappings.Operations[0].Value)
+		if mappings.Operations[1].Value != "id:user_id" {
+			t.Errorf("expected value 'id:user_id', got '%s'", mappings.Operations[1].Value)
 		}
 
 		// Verify ignore operation
-		if mappings.Operations[1].Action != "ignore" {
-			t.Errorf("expected action 'ignore', got '%s'", mappings.Operations[1].Action)
+		if mappings.Operations[2].Action != "ignore" {
+			t.Errorf("expected action 'ignore', got '%s'", mappings.Operations[2].Action)
 		}
 
 		// Verify entity operation
-		if mappings.Operations[2].Action != "entity" {
-			t.Errorf("expected action 'entity', got '%s'", mappings.Operations[2].Action)
+		if mappings.Operations[3].Action != "entity" {
+			t.Errorf("expected action 'entity', got '%s'", mappings.Operations[3].Action)
 		}
-		if mappings.Operations[2].Value != "CustomEntity" {
-			t.Errorf("expected value 'CustomEntity', got '%s'", mappings.Operations[2].Value)
+		if mappings.Operations[3].Value != "CustomEntity" {
+			t.Errorf("expected value 'CustomEntity', got '%s'", mappings.Operations[3].Value)
 		}
 
 		// Verify property ignore operation
-		if mappings.Operations[3].Action != "ignore_property" {
-			t.Errorf("expected action 'ignore_property', got '%s'", mappings.Operations[3].Action)
+		if mappings.Operations[4].Action != "ignore_property" {
+			t.Errorf("expected action 'ignore_property', got '%s'", mappings.Operations[4].Action)
 		}
-		if mappings.Operations[3].Schema != "UserEntity" {
-			t.Errorf("expected schema 'UserEntity', got '%s'", mappings.Operations[3].Schema)
+		if mappings.Operations[4].Schema != "UserEntity" {
+			t.Errorf("expected schema 'UserEntity', got '%s'", mappings.Operations[4].Schema)
 		}
-		if mappings.Operations[3].Property != "internal_field" {
-			t.Errorf("expected property 'internal_field', got '%s'", mappings.Operations[3].Property)
+		if mappings.Operations[4].Property != "internal_field" {
+			t.Errorf("expected property 'internal_field', got '%s'", mappings.Operations[4].Property)
 		}
 
 		// Verify additional properties operation
-		if mappings.Operations[4].Action != "additional_properties" {
-			t.Errorf("expected action 'additional_properties', got '%s'", mappings.Operations[4].Action)
+		if mappings.Operations[5].Action != "additional_properties" {
+			t.Errorf("expected action 'additional_properties', got '%s'", mappings.Operations[5].Action)
 		}
-		if mappings.Operations[4].Schema != "ConfigEntity" {
-			t.Errorf("expected schema 'ConfigEntity', got '%s'", mappings.Operations[4].Schema)
+		if mappings.Operations[5].Schema != "ConfigEntity" {
+			t.Errorf("expected schema 'ConfigEntity', got '%s'", mappings.Operations[5].Schema)
 		}
-		if mappings.Operations[4].Property != "metadata" {
-			t.Errorf("expected property 'metadata', got '%s'", mappings.Operations[4].Property)
+		if mappings.Operations[5].Property != "metadata" {
+			t.Errorf("expected property 'metadata', got '%s'", mappings.Operations[5].Property)
 		}
 	})
 
@@ -698,6 +710,7 @@ func TestManualMappingStruct(t *testing.T) {
 		Value:    "param:field",
 		Schema:   "TestEntity",
 		Property: "test_property",
+		Entity:   "UserEntity",
 	}
 
 	if mapping.Path != "/test/path" {
@@ -718,12 +731,19 @@ func TestManualMappingStruct(t *testing.T) {
 	if mapping.Property != "test_property" {
 		t.Errorf("expected property 'test_property', got '%s'", mapping.Property)
 	}
+	if mapping.Entity != "UserEntity" {
+		t.Errorf("expected entity 'UserEntity', got '%s'", mapping.Entity)
+	}
 }
 
 // Test ManualMappings struct
 func TestManualMappingsStruct(t *testing.T) {
 	mappings := ManualMappings{
 		Operations: []ManualMapping{
+			{
+				Action: "enable",
+				Entity: "UserEntity",
+			},
 			{
 				Path:   "/test1",
 				Method: "GET",
@@ -738,15 +758,76 @@ func TestManualMappingsStruct(t *testing.T) {
 		},
 	}
 
-	if len(mappings.Operations) != 2 {
-		t.Errorf("expected 2 operations, got %d", len(mappings.Operations))
+	if len(mappings.Operations) != 3 {
+		t.Errorf("expected 3 operations, got %d", len(mappings.Operations))
 	}
 
-	if mappings.Operations[0].Path != "/test1" {
-		t.Errorf("expected first operation path '/test1', got '%s'", mappings.Operations[0].Path)
+	if mappings.Operations[0].Action != "enable" {
+		t.Errorf("expected first operation action 'enable', got '%s'", mappings.Operations[0].Action)
 	}
 
-	if mappings.Operations[1].Action != "match" {
-		t.Errorf("expected second operation action 'match', got '%s'", mappings.Operations[1].Action)
+	if mappings.Operations[1].Path != "/test1" {
+		t.Errorf("expected second operation path '/test1', got '%s'", mappings.Operations[1].Path)
 	}
+
+	if mappings.Operations[2].Action != "match" {
+		t.Errorf("expected third operation action 'match', got '%s'", mappings.Operations[2].Action)
+	}
+}
+func TestBuildEntityConfig(t *testing.T) {
+	t.Run("no enable actions", func(t *testing.T) {
+		mappings := &ManualMappings{
+			Operations: []ManualMapping{
+				{Path: "/users/{id}", Method: "get", Action: "match", Value: "id:user_id"},
+			},
+		}
+		config := buildEntityConfig(mappings)
+		if !config.HasExplicitEnabled {
+			t.Error("expected HasExplicitEnabled=true when no enable actions present")
+		}
+		if len(config.EnabledEntities) != 0 {
+			t.Error("expected empty EnabledEntities when no enable actions present")
+		}
+	})
+
+	t.Run("with enable actions", func(t *testing.T) {
+		mappings := &ManualMappings{
+			Operations: []ManualMapping{
+				{Action: "enable", Entity: "UserEntity"},
+				{Action: "enable", Entity: "ProductEntity"},
+			},
+		}
+		config := buildEntityConfig(mappings)
+		if config.HasExplicitEnabled {
+			t.Error("expected HasExplicitEnabled=false when enable actions present")
+		}
+		if len(config.EnabledEntities) != 2 {
+			t.Errorf("expected 2 enabled entities, got %d", len(config.EnabledEntities))
+		}
+		if !config.EnabledEntities["UserEntity"] || !config.EnabledEntities["ProductEntity"] {
+			t.Error("expected UserEntity and ProductEntity to be enabled")
+		}
+	})
+}
+
+func TestEntityConfigShouldProcessEntity(t *testing.T) {
+	t.Run("process all entities", func(t *testing.T) {
+		config := &EntityConfig{EnabledEntities: make(map[string]bool), HasExplicitEnabled: true}
+		if !config.ShouldProcessEntity("AnyEntity") {
+			t.Error("expected to process entity when HasExplicitEnabled=true")
+		}
+	})
+
+	t.Run("process only enabled entities", func(t *testing.T) {
+		config := &EntityConfig{
+			EnabledEntities:    map[string]bool{"UserEntity": true},
+			HasExplicitEnabled: false,
+		}
+		if !config.ShouldProcessEntity("UserEntity") {
+			t.Error("expected to process enabled entity")
+		}
+		if config.ShouldProcessEntity("DisabledEntity") {
+			t.Error("expected not to process disabled entity")
+		}
+	})
 }

--- a/scripts/overlay/manual-mappings_test.go
+++ b/scripts/overlay/manual-mappings_test.go
@@ -29,33 +29,33 @@ func TestLoadManualMappings(t *testing.T) {
 		testMappings := ManualMappings{
 			Operations: []ManualMapping{
 				{
-					Action: "enable",
+					Action: Enable,
 					Entity: "UserEntity",
 				},
 				{
 					Path:   "/users/{id}",
 					Method: "get",
-					Action: "match",
+					Action: Match,
 					Value:  "id:user_id",
 				},
 				{
 					Path:   "/admin/debug",
 					Method: "get",
-					Action: "ignore",
+					Action: Ignore,
 				},
 				{
 					Path:   "/special/endpoint",
 					Method: "post",
-					Action: "entity",
+					Action: Entity,
 					Value:  "CustomEntity",
 				},
 				{
-					Action:   "ignore_property",
+					Action:   IgnoreProperty,
 					Schema:   "UserEntity",
 					Property: "internal_field",
 				},
 				{
-					Action:   "additional_properties",
+					Action:   AdditionalProperties,
 					Schema:   "ConfigEntity",
 					Property: "metadata",
 				},
@@ -88,7 +88,7 @@ func TestLoadManualMappings(t *testing.T) {
 		}
 
 		// Verify enable operation
-		if mappings.Operations[0].Action != "enable" {
+		if mappings.Operations[0].Action != Enable {
 			t.Errorf("expected action 'enable', got '%s'", mappings.Operations[0].Action)
 		}
 		if mappings.Operations[0].Entity != "UserEntity" {
@@ -99,7 +99,7 @@ func TestLoadManualMappings(t *testing.T) {
 		if mappings.Operations[1].Path != "/users/{id}" {
 			t.Errorf("expected path '/users/{id}', got '%s'", mappings.Operations[1].Path)
 		}
-		if mappings.Operations[1].Action != "match" {
+		if mappings.Operations[1].Action != Match {
 			t.Errorf("expected action 'match', got '%s'", mappings.Operations[1].Action)
 		}
 		if mappings.Operations[1].Value != "id:user_id" {
@@ -107,12 +107,12 @@ func TestLoadManualMappings(t *testing.T) {
 		}
 
 		// Verify ignore operation
-		if mappings.Operations[2].Action != "ignore" {
+		if mappings.Operations[2].Action != Ignore {
 			t.Errorf("expected action 'ignore', got '%s'", mappings.Operations[2].Action)
 		}
 
 		// Verify entity operation
-		if mappings.Operations[3].Action != "entity" {
+		if mappings.Operations[3].Action != Entity {
 			t.Errorf("expected action 'entity', got '%s'", mappings.Operations[3].Action)
 		}
 		if mappings.Operations[3].Value != "CustomEntity" {
@@ -120,7 +120,7 @@ func TestLoadManualMappings(t *testing.T) {
 		}
 
 		// Verify property ignore operation
-		if mappings.Operations[4].Action != "ignore_property" {
+		if mappings.Operations[4].Action != IgnoreProperty {
 			t.Errorf("expected action 'ignore_property', got '%s'", mappings.Operations[4].Action)
 		}
 		if mappings.Operations[4].Schema != "UserEntity" {
@@ -131,7 +131,7 @@ func TestLoadManualMappings(t *testing.T) {
 		}
 
 		// Verify additional properties operation
-		if mappings.Operations[5].Action != "additional_properties" {
+		if mappings.Operations[5].Action != AdditionalProperties {
 			t.Errorf("expected action 'additional_properties', got '%s'", mappings.Operations[5].Action)
 		}
 		if mappings.Operations[5].Schema != "ConfigEntity" {
@@ -190,31 +190,31 @@ func TestGetManualParameterMatch(t *testing.T) {
 			{
 				Path:   "/users/{user_id}",
 				Method: "get",
-				Action: "match",
+				Action: Match,
 				Value:  "user_id:id",
 			},
 			{
 				Path:   "/posts/{post_id}",
 				Method: "get",
-				Action: "match",
+				Action: Match,
 				Value:  "post_id:slug",
 			},
 			{
 				Path:   "/complex/{param}",
 				Method: "post",
-				Action: "match",
+				Action: Match,
 				Value:  "param:nested.field.id",
 			},
 			{
 				Path:   "/wrong-action/{id}",
 				Method: "get",
-				Action: "ignore", // Not a match action
+				Action: Ignore, // Not a match action
 				Value:  "id:something",
 			},
 			{
 				Path:   "/malformed/{id}",
 				Method: "get",
-				Action: "match",
+				Action: Match,
 				Value:  "malformed_value", // No colon separator
 			},
 		},
@@ -333,17 +333,17 @@ func TestShouldIgnoreOperation(t *testing.T) {
 			{
 				Path:   "/internal/debug",
 				Method: "get",
-				Action: "ignore",
+				Action: Ignore,
 			},
 			{
 				Path:   "/admin/reset",
 				Method: "post",
-				Action: "ignore",
+				Action: Ignore,
 			},
 			{
 				Path:   "/not-ignored",
 				Method: "get",
-				Action: "match", // Different action, should not ignore
+				Action: Match, // Different action, should not ignore
 				Value:  "param:field",
 			},
 		},
@@ -403,19 +403,19 @@ func TestGetManualEntityMapping(t *testing.T) {
 			{
 				Path:   "/special/endpoint",
 				Method: "get",
-				Action: "entity",
+				Action: Entity,
 				Value:  "SpecialEntity",
 			},
 			{
 				Path:   "/custom/resource",
 				Method: "post",
-				Action: "entity",
+				Action: Entity,
 				Value:  "CustomResourceEntity",
 			},
 			{
 				Path:   "/not-entity",
 				Method: "get",
-				Action: "ignore", // Different action
+				Action: Ignore, // Different action
 			},
 		},
 	}
@@ -481,38 +481,38 @@ func TestGetManualPropertyIgnores(t *testing.T) {
 	mappings := &ManualMappings{
 		Operations: []ManualMapping{
 			{
-				Action:   "ignore_property",
+				Action:   IgnoreProperty,
 				Schema:   "UserEntity",
 				Property: "internal_field",
 			},
 			{
-				Action:   "ignore_property",
+				Action:   IgnoreProperty,
 				Schema:   "UserEntity",
 				Property: "debug_info",
 			},
 			{
-				Action:   "ignore_property",
+				Action:   IgnoreProperty,
 				Schema:   "ProductEntity",
 				Property: "admin_notes",
 			},
 			{
-				Action:   "ignore_property",
+				Action:   IgnoreProperty,
 				Schema:   "UserEntity",
 				Property: "temp_data",
 			},
 			{
 				// Missing schema - should be ignored
-				Action:   "ignore_property",
+				Action:   IgnoreProperty,
 				Property: "orphaned_property",
 			},
 			{
 				// Missing property - should be ignored
-				Action: "ignore_property",
+				Action: IgnoreProperty,
 				Schema: "EmptyEntity",
 			},
 			{
 				// Different action - should be ignored
-				Action:   "match",
+				Action:   Match,
 				Schema:   "UserEntity",
 				Property: "not_ignored",
 			},
@@ -565,38 +565,38 @@ func TestGetAdditionalPropertiesMappings(t *testing.T) {
 	mappings := &ManualMappings{
 		Operations: []ManualMapping{
 			{
-				Action:   "additional_properties",
+				Action:   AdditionalProperties,
 				Schema:   "UserEntity",
 				Property: "metadata",
 			},
 			{
-				Action:   "additional_properties",
+				Action:   AdditionalProperties,
 				Schema:   "UserEntity",
 				Property: "settings.preferences",
 			},
 			{
-				Action:   "additional_properties",
+				Action:   AdditionalProperties,
 				Schema:   "ProductEntity",
 				Property: "custom_fields",
 			},
 			{
-				Action:   "additional_properties",
+				Action:   AdditionalProperties,
 				Schema:   "UserEntity",
 				Property: "dynamic.config.values",
 			},
 			{
 				// Missing schema - should be ignored
-				Action:   "additional_properties",
+				Action:   AdditionalProperties,
 				Property: "orphaned",
 			},
 			{
 				// Missing property - should be ignored
-				Action: "additional_properties",
+				Action: AdditionalProperties,
 				Schema: "EmptyEntity",
 			},
 			{
 				// Different action - should be ignored
-				Action:   "ignore",
+				Action:   IgnoreProperty,
 				Schema:   "UserEntity",
 				Property: "not_additional",
 			},
@@ -706,7 +706,7 @@ func TestManualMappingStruct(t *testing.T) {
 	mapping := ManualMapping{
 		Path:     "/test/path",
 		Method:   "GET",
-		Action:   "match",
+		Action:   Match,
 		Value:    "param:field",
 		Schema:   "TestEntity",
 		Property: "test_property",
@@ -719,7 +719,7 @@ func TestManualMappingStruct(t *testing.T) {
 	if mapping.Method != "GET" {
 		t.Errorf("expected method 'GET', got '%s'", mapping.Method)
 	}
-	if mapping.Action != "match" {
+	if mapping.Action != Match {
 		t.Errorf("expected action 'match', got '%s'", mapping.Action)
 	}
 	if mapping.Value != "param:field" {
@@ -741,18 +741,18 @@ func TestManualMappingsStruct(t *testing.T) {
 	mappings := ManualMappings{
 		Operations: []ManualMapping{
 			{
-				Action: "enable",
+				Action: Enable,
 				Entity: "UserEntity",
 			},
 			{
 				Path:   "/test1",
 				Method: "GET",
-				Action: "ignore",
+				Action: IgnoreProperty,
 			},
 			{
 				Path:   "/test2",
 				Method: "POST",
-				Action: "match",
+				Action: Match,
 				Value:  "param:field",
 			},
 		},
@@ -762,7 +762,7 @@ func TestManualMappingsStruct(t *testing.T) {
 		t.Errorf("expected 3 operations, got %d", len(mappings.Operations))
 	}
 
-	if mappings.Operations[0].Action != "enable" {
+	if mappings.Operations[0].Action != Enable {
 		t.Errorf("expected first operation action 'enable', got '%s'", mappings.Operations[0].Action)
 	}
 
@@ -770,7 +770,7 @@ func TestManualMappingsStruct(t *testing.T) {
 		t.Errorf("expected second operation path '/test1', got '%s'", mappings.Operations[1].Path)
 	}
 
-	if mappings.Operations[2].Action != "match" {
+	if mappings.Operations[2].Action != Match {
 		t.Errorf("expected third operation action 'match', got '%s'", mappings.Operations[2].Action)
 	}
 }
@@ -778,7 +778,7 @@ func TestBuildEntityConfig(t *testing.T) {
 	t.Run("no enable actions", func(t *testing.T) {
 		mappings := &ManualMappings{
 			Operations: []ManualMapping{
-				{Path: "/users/{id}", Method: "get", Action: "match", Value: "id:user_id"},
+				{Path: "/users/{id}", Method: "get", Action: Match, Value: "id:user_id"},
 			},
 		}
 		config := buildEntityConfig(mappings)
@@ -793,8 +793,8 @@ func TestBuildEntityConfig(t *testing.T) {
 	t.Run("with enable actions", func(t *testing.T) {
 		mappings := &ManualMappings{
 			Operations: []ManualMapping{
-				{Action: "enable", Entity: "UserEntity"},
-				{Action: "enable", Entity: "ProductEntity"},
+				{Action: Enable, Entity: "UserEntity"},
+				{Action: Enable, Entity: "ProductEntity"},
 			},
 		}
 		config := buildEntityConfig(mappings)


### PR DESCRIPTION
This pull request adds the ability to enable specific resources and data sources to support a gradual rollout of the V2 provider. To enable a resource we add an 'enable' action to manual-mappings.yaml which contains the desired entity name.

By default, all entities are enabled. Once a single enable action is added, only the enabled entities will be generated as Terraform resources/data sources.

We continue to process the other entities and assign x-speakeasy-entity extensions to all entities as to not break dependencies and relationships between parent/sub schemas, but do not assign x-speakeasy-entity-operations to the operations for any non-enabled entity, thus preventing resource/data source generation.

Overlay with only 4 entity operations (Functionality Entity CRUD operations)
<img width="1431" height="996" alt="Screenshot 2025-07-31 at 5 07 34 PM" src="https://github.com/user-attachments/assets/f8329dc4-6f58-43c0-86a0-3ec56ede2bef" />

Successful generation with a single enabled entity: FunctionalityEntity:
<img width="728" height="408" alt="Screenshot 2025-07-31 at 5 15 54 PM" src="https://github.com/user-attachments/assets/f9d0f1f8-6207-40cd-b3e3-c1eef12168ba" />

Resulting Resource and Data Source:
<img width="320" height="124" alt="Screenshot 2025-07-31 at 5 16 10 PM" src="https://github.com/user-attachments/assets/d1a6953f-9228-42bf-aaf1-2ff621a20045" />
